### PR TITLE
better handling of cluster internals

### DIFF
--- a/geosnap/analyze/analytics.py
+++ b/geosnap/analyze/analytics.py
@@ -107,7 +107,7 @@ def cluster(
         {method: labels, time_var: data[time_var], id_var: data[id_var]}
     )
     clusters.set_index([time_var, id_var], inplace=True)
-    gdf = gdf.join(clusters)
+    gdf = gdf.join(clusters, how="left")
     gdf = gdf.reset_index()
     if return_model:
         return gdf, model
@@ -236,7 +236,7 @@ def cluster_spatial(
             {method: labels, time_var: df[time_var], id_var: df[id_var]}
         )
         clusters.set_index([time_var, id_var], inplace=True)
-        dfs.append(gdf.loc[time].join(clusters))
+        dfs.append(gdf.loc[time].join(clusters, how="left"))
     gdf = pd.concat(dfs).reset_index()
     if return_model:
         return gdf, model

--- a/geosnap/analyze/analytics.py
+++ b/geosnap/analyze/analytics.py
@@ -60,8 +60,8 @@ def cluster(
         which column on the long-form dataframe identifies the stable units
         over time. In a wide-form dataset, this would be the unique index
     scaler: str or sklearn.preprocessing.Scaler
-        
-    **kwargs
+        a scikit-learn preprocessing class that will be used to rescale the
+        data. Defaults to StandardScaler
 
     Returns
     -------
@@ -156,8 +156,9 @@ def cluster_spatial(
     id_var: str
         which column on the long-form dataframe identifies the stable units
         over time. In a wide-form dataset, this would be the unique index
-    **kwargs
-
+    scaler: str or sklearn.preprocessing.Scaler
+        a scikit-learn preprocessing class that will be used to rescale the
+        data. Defaults to StandardScaler
 
     Returns
     -------

--- a/geosnap/analyze/analytics.py
+++ b/geosnap/analyze/analytics.py
@@ -59,6 +59,8 @@ def cluster(
     id_var: str
         which column on the long-form dataframe identifies the stable units
         over time. In a wide-form dataset, this would be the unique index
+    scaler: str or sklearn.preprocessing.Scaler
+        
     **kwargs
 
     Returns
@@ -66,22 +68,25 @@ def cluster(
     pandas.DataFrame with a column of neighborhood cluster labels appended
     as a new column. Will overwrite columns of the same name.
     """
-    assert columns, "You must provide a subset of columns as input"
-    assert method, "You must choose a clustering algorithm to use"
+    if not columns:
+        raise ValueError("You must provide a subset of columns as input")
+    if not method:
+        raise ValueError("You must choose a clustering algorithm to use")
 
     times = gdf[time_var].unique()
     gdf = gdf.set_index([time_var, id_var])
 
+    # this is the dataset we'll operate on
     data = gdf.copy()[columns]
     data = data.dropna(how="any", subset=columns)
 
+    # if the user doesn't specify, use the standard scalar
     if not scaler:
         scaler = StandardScaler()
     for time in times:
         data.loc[time] = scaler.fit_transform(data.loc[time].values)
-    # the rescalar can create NaNs
+    # the rescalar can create nans if a column has no variance, so fill with 0
     data = data.fillna(0)
-    # opset.reset_index(inplace=True, drop=True)
 
     specification = {
         "ward": ward,
@@ -91,6 +96,8 @@ def cluster(
         "spectral": spectral,
         "hdbscan": hdbscan,
     }
+
+    # run the cluster model then join the labels back to the original data
     model = specification[method](
         data, n_clusters=n_clusters, best_model=best_model, verbose=verbose, **kwargs
     )
@@ -110,15 +117,15 @@ def cluster(
 def cluster_spatial(
     gdf,
     n_clusters=6,
-    weights_type="rook",
+    spatial_weights="rook",
     method=None,
-    best_model=False,
     columns=None,
     threshold_variable="count",
     threshold=10,
     time_var="year",
     id_var="geoid",
     return_model=False,
+    scaler=None,
     **kwargs,
 ):
     """Create a *spatial* geodemographic typology by running a cluster
@@ -135,8 +142,6 @@ def cluster_spatial(
         spatial weights matrix specification` (the default is "rook").
     method : str
         the clustering algorithm used to identify neighborhood types
-    best_model : type
-        Description of parameter `best_model` (the default is False).
     columns : list-like
         subset of columns on which to apply the clustering
     threshold_variable : str
@@ -160,54 +165,23 @@ def cluster_spatial(
     appended as a new column. Will overwrite columns of the same name.
 
     """
-    assert columns, "You must provide a subset of columns as input"
-    assert method, "You must choose a clustering algorithm to use"
-    gdf = gdf.copy().reset_index()
-    cols = [time_var, id_var, "geometry"]
+    if not columns:
+        raise ValueError("You must provide a subset of columns as input")
+    if not method:
+        raise ValueError("You must choose a clustering algorithm to use")
 
-    if threshold_variable == "count":
-        allcols = columns + cols
-        data = gdf[allcols].copy()
-        data = data.dropna(how="any")
-        data[columns] = data.groupby(time_var)[columns].apply(
-            lambda x: (x - x.mean()) / x.std(ddof=0)
-        )
-        data[columns] = data[columns].fillna(0)
+    times = gdf[time_var].unique()
+    gdf = gdf.set_index([time_var, id_var])
 
-    elif threshold_variable is not None:
-        threshold_var = data[threshold_variable]
-        allcols = list(columns).remove(threshold_variable) + cols
-        data = gdf[allcols].copy()
-        data = data.dropna(how="any")
-        data[columns] = data.groupby(time_var)[columns].apply(
-            lambda x: (x - x.mean()) / x.std(ddof=0)
-        )
-        data[columns] = data[columns].fillna(0)
+    # this is the dataset we'll operate on
+    data = gdf.copy()[columns + ["geometry"]]
 
+    contiguity_weights = {"queen": Queen, "rook": Rook}
+
+    if spatial_weights in contiguity_weights.keys():
+        W = contiguity_weights[spatial_weights]
     else:
-        allcols = columns + cols
-        data = gdf[allcols].copy()
-        data = data.dropna(how="any")
-        data[columns] = data.groupby(time_var)[columns].apply(
-            lambda x: (x - x.mean()) / x.std(ddof=0)
-        )
-        data[columns] = data[columns].fillna(0)
-
-    def _build_data(data, time, weights_type):
-        df = data[data[time_var] == time].dropna(how="any")
-        weights = {"queen": Queen, "rook": Rook}
-        w = weights[weights_type].from_dataframe(df)
-        knnw = KNN.from_dataframe(df, k=1)
-
-        return df, w, knnw
-
-    times = data[time_var].unique().tolist()
-    annual = []
-    for time in times:
-        df, w, knnw = _build_data(data, time, weights_type)
-        annual.append([df, w, knnw])
-
-    datasets = dict(zip(times, annual))
+        W = spatial_weights
 
     specification = {
         "azp": azp,
@@ -217,46 +191,52 @@ def cluster_spatial(
         "max_p": max_p,
     }
 
-    clusters = []
-    for _, val in datasets.items():
-        if threshold_variable == "count":
-            threshold_var = np.ones(len(val[0]))
-            val[1] = attach_islands(val[1], val[2])
+    # if the user doesn't specify, use the standard scalar
+    if not scaler:
+        scaler = StandardScaler()
 
-        elif threshold_variable:
-            threshold_var = threshold_var[threshold.index.isin(val[0][id_var])].values
-            try:
-                val[1] = attach_islands(val[1], val[2])
-            except:
-                pass
+    ws = {}
+    clusters = []
+    dfs = []
+    # loop over each time period, standardize the data and build a weights matrix
+    for time in times:
+        df = data.loc[time].dropna(how="any", subset=columns).reset_index()
+        df[time_var] = time
+        df[columns] = scaler.fit_transform(df[columns].values)
+        w0 = W.from_dataframe(df)
+        w1 = KNN.from_dataframe(df, k=1)
+        ws = [w0, w1]
+        # the rescalar can create nans if a column has no variance, so fill with 0
+        df = df.fillna(0)
+
+        if threshold_variable and threshold_variable != "count":
+            data[threshold_variable] = gdf[threshold_variable]
+            threshold_var = data.threshold_variable.values
+            ws[0] = attach_islands(ws[0], ws[1])
+
+        elif threshold_variable == "count":
+            threshold_var = np.ones(len(data.loc[time]))
+            ws[0] = attach_islands(ws[0], ws[1])
+
         else:
             threshold_var = None
+
         model = specification[method](
-            val[0][columns],
-            w=val[1],
+            df[columns],
+            w=ws[0],
             n_clusters=n_clusters,
             threshold_variable=threshold_var,
             threshold=threshold,
             **kwargs,
         )
+
         labels = model.labels_.astype(str)
-        labels = pd.DataFrame(
-            {method: labels, time_var: val[0][time_var], id_var: val[0][id_var]}
+        clusters = pd.DataFrame(
+            {method: labels, time_var: df[time_var], id_var: df[id_var]}
         )
-        clusters.append(labels)
-
-    clusters = pd.concat(clusters)
-    clusters.set_index(id_var)
-    clusters["joinkey"] = clusters[id_var] + clusters[time_var].astype(str)
-    clusters = clusters.drop(columns=time_var)
-    gdf["joinkey"] = gdf[id_var] + gdf[time_var].astype(str)
-    if method in gdf.columns:
-        gdf.drop(columns=method, inplace=True)
-    gdf = gdf.merge(clusters.drop(columns=[id_var]), on="joinkey", how="left")
-    gdf = gdf.drop(columns=["joinkey"])
-    gdf.set_index(id_var, inplace=True)
-
+        clusters.set_index([time_var, id_var], inplace=True)
+        dfs.append(gdf.loc[time].join(clusters))
+    gdf = pd.concat(dfs).reset_index()
     if return_model:
         return gdf, model
-
     return gdf

--- a/geosnap/data/data.py
+++ b/geosnap/data/data.py
@@ -945,13 +945,14 @@ class Community(object):
     def cluster_spatial(
         self,
         n_clusters=6,
-        weights_type="rook",
+        spatial_weights="rook",
         method=None,
         best_model=False,
         columns=None,
         threshold_variable="count",
         threshold=10,
         return_model=False,
+        scaler=None,
         **kwargs
     ):
         """Create a *spatial* geodemographic typology by running a cluster
@@ -993,7 +994,7 @@ class Community(object):
             gdf, model = _cluster_spatial(
                 gdf=self.gdf.copy(),
                 n_clusters=n_clusters,
-                weights_type=weights_type,
+                spatial_weights=spatial_weights,
                 method=method,
                 best_model=best_model,
                 columns=columns,
@@ -1007,7 +1008,7 @@ class Community(object):
             gdf = _cluster_spatial(
                 gdf=self.gdf.copy(),
                 n_clusters=n_clusters,
-                weights_type=weights_type,
+                spatial_weights=spatial_weights,
                 method=method,
                 best_model=best_model,
                 columns=columns,

--- a/geosnap/data/data.py
+++ b/geosnap/data/data.py
@@ -887,7 +887,8 @@ class Community(object):
         columns=None,
         verbose=False,
         return_model=False,
-        **kwargs
+        scaler=None,
+        **kwargs,
     ):
         """Create a geodemographic typology by running a cluster analysis on
         the study area's neighborhood attributes
@@ -910,6 +911,9 @@ class Community(object):
         return_model : bool
             whether to return the underlying cluster model instance for further
             analysis
+        scaler: str or sklearn.preprocessing.Scaler
+            a scikit-learn preprocessing class that will be used to rescale the
+            data. Defaults to StandardScaler
 
         Returns
         -------
@@ -926,7 +930,7 @@ class Community(object):
                 columns=columns,
                 verbose=verbose,
                 return_model=return_model,
-                **kwargs
+                **kwargs,
             )
             return Community(gdf, harmonized=harmonized), model
         else:
@@ -938,7 +942,7 @@ class Community(object):
                 columns=columns,
                 verbose=verbose,
                 return_model=return_model,
-                **kwargs
+                **kwargs,
             )
             return Community(gdf, harmonized=harmonized)
 
@@ -953,7 +957,7 @@ class Community(object):
         threshold=10,
         return_model=False,
         scaler=None,
-        **kwargs
+        **kwargs,
     ):
         """Create a *spatial* geodemographic typology by running a cluster
         analysis on the metro area's neighborhood attributes and including a
@@ -982,6 +986,9 @@ class Community(object):
         return_model : bool
             whether to return the underlying cluster model instance for further
             analysis
+        scaler: str or sklearn.preprocessing.Scaler
+            a scikit-learn preprocessing class that will be used to rescale the
+            data. Defaults to StandardScaler
 
         Returns
         -------
@@ -1001,7 +1008,7 @@ class Community(object):
                 threshold_variable=threshold_variable,
                 threshold=threshold,
                 return_model=return_model,
-                **kwargs
+                **kwargs,
             )
             return Community(gdf, harmonized=True), model
         else:
@@ -1015,7 +1022,7 @@ class Community(object):
                 threshold_variable=threshold_variable,
                 threshold=threshold,
                 return_model=return_model,
-                **kwargs
+                **kwargs,
             )
             return Community(gdf, harmonized=harmonized)
 

--- a/geosnap/data/data.py
+++ b/geosnap/data/data.py
@@ -1100,7 +1100,7 @@ class Community(object):
                 years=years,
             )
 
-        return cls(gdf=gdf, harmonized=True)
+        return cls(gdf=gdf.reset_index(), harmonized=True)
 
     @classmethod
     def from_ncdb(
@@ -1175,7 +1175,7 @@ class Community(object):
                 years=years,
             )
 
-        return cls(gdf=gdf, harmonized=True)
+        return cls(gdf=gdf.reset_index(), harmonized=True)
 
     @classmethod
     def from_census(

--- a/geosnap/tests/test_clusters.py
+++ b/geosnap/tests/test_clusters.py
@@ -23,25 +23,25 @@ def test_gm():
 def test_ward():
 
     r = reno.cluster(columns=columns, method="ward")
-    assert len(r.gdf.ward.unique()) == 6
+    assert len(r.gdf.ward.unique()) == 7
 
 
 def test_spectral():
 
     r = reno.cluster(columns=columns, method="spectral")
-    assert len(r.gdf.spectral.unique()) == 6
+    assert len(r.gdf.spectral.unique()) == 7
 
 
 def test_kmeans():
 
     r = reno.cluster(columns=columns, method="kmeans")
-    assert len(r.gdf.kmeans.unique()) == 6
+    assert len(r.gdf.kmeans.unique()) == 7
 
 
 def test_aff_prop():
 
     r = reno.cluster(columns=columns, method="affinity_propagation", preference=-100)
-    assert len(r.gdf.affinity_propagation.unique()) == 3
+    assert len(r.gdf.affinity_propagation.unique()) == 4
 
 
 def test_hdbscan():
@@ -62,7 +62,7 @@ def test_spenc():
 def test_maxp():
 
     r = reno.cluster_spatial(columns=columns, method="max_p", initial=10)
-    assert len(r.gdf.max_p.unique()) > 10
+    assert len(r.gdf.max_p.unique()) >= 10
 
 
 def test_ward_spatial():

--- a/geosnap/tests/test_clusters.py
+++ b/geosnap/tests/test_clusters.py
@@ -56,7 +56,7 @@ def test_hdbscan():
 def test_spenc():
 
     r = reno.cluster_spatial(columns=columns, method="spenc")
-    assert len(r.gdf.spenc.unique()) == 7
+    assert len(r.gdf.spenc.unique()) == 6
 
 
 def test_maxp():
@@ -68,15 +68,15 @@ def test_maxp():
 def test_ward_spatial():
 
     r = reno.cluster_spatial(columns=columns, method="ward_spatial", n_clusters=7)
-    assert len(r.gdf.ward_spatial.unique()) == 8
+    assert len(r.gdf.ward_spatial.unique()) == 7
 
 
 def test_skater():
 
     r = reno.cluster_spatial(columns=columns, method="skater", n_clusters=10)
-    assert len(r.gdf.skater.unique()) == 11
+    assert len(r.gdf.skater.unique()) == 10
 
 
 def test_azp():
     r = reno.cluster_spatial(columns=columns, method="azp", n_clusters=7)
-    assert len(r.gdf.azp.unique()) == 8
+    assert len(r.gdf.azp.unique()) == 7

--- a/geosnap/tests/test_community.py
+++ b/geosnap/tests/test_community.py
@@ -13,19 +13,19 @@ except KeyError:
 def test_Community_from_cbsa():
 
     la = data.Community.from_ltdb(msa_fips="31080")
-    assert la.gdf.shape == (14617, 193)
+    assert la.gdf.shape == (14617, 194)
 
 
 def test_Community_from_stcofips():
 
     mn = data.Community.from_ltdb(state_fips="27", county_fips=["053", "055"])
-    assert mn.gdf.shape == (5719, 193)
+    assert mn.gdf.shape == (5719, 194)
 
 
 def test_Community_from_indices():
 
     chi = data.Community.from_ncdb(fips=["17031", "17019"])
-    assert chi.gdf.shape == (6797, 78)
+    assert chi.gdf.shape == (6797, 79)
 
 
 def test_Community_from_boundary():
@@ -33,7 +33,7 @@ def test_Community_from_boundary():
 
     reno = msas[msas["geoid"] == "39900"]
     rn = data.Community.from_ltdb(boundary=reno)
-    assert rn.gdf.shape == (555, 194)
+    assert rn.gdf.shape == (555, 195)
 
 
 def test_Community_from_census():


### PR DESCRIPTION
this PR makes a few improvements to the clustering internals

- it uses multiindices rather than creating several hacky columns then dropping them
- it adds a new `scaler` argument that accepts any `sklearn.preprocessing` class to scale inputs
- more flexible handling of spatial weights, including allowing users to provide their own (i.e. allow distance-based weights for algos that can support them)