### PR TITLE
ENH: Makefile for joint tobler and geosnap dev environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Linux specific Docker file for geosnap
 
-TOBLER = "../tobler"
 container:
 	docker build -t geosnap ./infrastructure/docker/
 
@@ -22,7 +21,7 @@ cli2s:
 	docker run -it -p 8888:8888 -e "DLPATH=/home/jovyan/.local/share/geosnap/data" -v ${PWD}:/home/jovyan -v ${HOME}/.local:/home/jovyan/.local geosnap sh -c "/home/jovyan/develop.sh && /bin/bash"
 
 cli2tg:
-	docker run -it -p 8888:8888 -e "DLPATH=/home/jovyan/.local/share/geosnap/data" -v ${PWD}:/home/jovyan -v ${TOBLER}:/home/jovyan/tobler -v ${HOME}/.local:/home/jovyan/.local geosnap sh -c "/home/jovyan/develop.sh && /bin/bash"
+	docker run -it -p 8888:8888 -e "DLPATH=/home/jovyan/.local/share/geosnap/data" -v ${PWD}:/home/jovyan -v $(subst geosnap,tobler, ${PWD}):/home/jovyan/tobler -v ${HOME}/.local:/home/jovyan/.local geosnap sh -c "/home/jovyan/develop.sh && /bin/bash"
 
 
 test:

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -19,4 +19,5 @@ RUN conda install pytest
 RUN conda install nose nose-progressive coverage coveralls pytest-cov pytest-mpl
 RUN pip install dash dash-bootstrap-components
 RUN pip install -U statsmodels==0.10.0rc2 --pre
+RUN conda install descartes
 COPY develop.sh /home/jovyan/develop.sh


### PR DESCRIPTION
This assumes that geosnap and tobler have been clonned into the same parent directory.

Allows for co-development while working on geosnap.