### PR TITLE
remove unnecessary options from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ def setup_package():
         license="BSD",
         py_modules=["geosnap"],
         packages=find_packages(),
-        setup_requires=["pytest-runner"],
-        tests_require=["pytest"],
         keywords=["spatial statistics", "neighborhoods", "demography"],
         classifiers=[
             "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ def setup_package():
         ],
         install_requires=install_reqs,
         extras_require=extras_reqs,
-        cmdclass={"build_py": build_py},
         include_package_data=True,
         package_data={"geosnap": ["io/variables.csv", "io/stfipstable.csv", "io/lodes.csv"]},
         python_requires=">3.5",


### PR DESCRIPTION
there's old stuff in there that got copied over from some other package's setup.py, and besides being unnecessary its causing build failures on conda 