### PR TITLE
bump pyarrow

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - palettable
   - pip
   - tqdm
-  - quilt3
+  - quilt3 ==3.1.8
   - xlrd
   - region >=0.2.0
   - tobler

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - scikit-learn
   - seaborn
-  - pyarrow =0.13
+  - pyarrow >=0.14.1
   - appdirs
   - dash
   - dash-bootstrap-components

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ dash-bootstrap-components
 tqdm
 quilt3
 region>=0.2.1
-pyarrow==0.13
+pyarrow>=0.14.1
 tobler

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ palettable
 dash
 dash-bootstrap-components
 tqdm
-quilt3
+quilt3==3.1.8
 region>=0.2.1
 pyarrow>=0.14.1
 tobler


### PR DESCRIPTION
we had pinned an older version of pyarrow for quilt compatibility, but quilt has moved past that pin, so it can cause some installation trouble