### PR TITLE
check for multiple crs in from_geodataframes constructor

### DIFF
--- a/geosnap/_community.py
+++ b/geosnap/_community.py
@@ -1888,5 +1888,11 @@ class Community:
             neighborhood units over time.
 
         """
+        assert len(set([gdf.crs for gdf in gdfs])) == 1, (
+            "These geodataframes have different CRS."
+            " A community constructed from these GeoDataFrames will have different CRS for different time periods or neighborhoods."
+            " In order to fix this error, please make the CRS for each GeoDataFrame the same."
+            " See: https://geopandas.org/projections.html for more inforamtion."
+        )
         gdf = pd.concat(gdfs, sort=True)
         return cls(gdf=gdf)

--- a/geosnap/tests/test_community.py
+++ b/geosnap/tests/test_community.py
@@ -49,6 +49,17 @@ def test_Community_from_gdfs():
 
     assert Community.from_geodataframes([t90, t00]).gdf.shape == (380, 192)
 
+def test_Community_from_gdfs_crs():
+
+    t90 = datasets.tracts_1990()
+    t00 = datasets.tracts_2000()
+    t90 = t90.to_crs(4236)
+    t00 = t00.to_crs(3857)
+    try:
+        Community.from_geodataframes([t90, t00])
+    except AssertionError:
+        print("From_gdfs constructor successfully detects inconsistent crs.")
+        pass
 
 def test_Community_from_lodes():
     dc = Community.from_lodes(state_fips="11", years=[2010, 2015])


### PR DESCRIPTION
- if crs are all the same, then a set will have a length == 1.

Addresses #276. This is my first shot at this. Let me know if you want any implementation changes on it, like telling the user which frames have mismatches, or raising an error/warning instead of using an `assert` statement @knaaptime.

Tested using the Chicago GeoDataFrames from `02_creating_community_datasets`
![image](https://user-images.githubusercontent.com/64164151/98198266-7fe41280-1f20-11eb-8d16-823bca3288f3.png)
