### PR TITLE
change channel priority to strict

### DIFF
--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -9,7 +9,7 @@ dependencies:
   - cenpy
   - geopandas
   - hdbscan
-  - matplotlib >=3.3.4
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -9,7 +9,7 @@ dependencies:
   - cenpy
   - geopandas
   - hdbscan
-  - matplotlib
+  - matplotlib >=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -9,7 +9,7 @@ dependencies:
   - cenpy
   - geopandas
   - hdbscan
-  - matplotlib >=3.3.4
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -9,7 +9,7 @@ dependencies:
   - cenpy
   - geopandas
   - hdbscan
-  - matplotlib
+  - matplotlib >=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -8,7 +8,7 @@ dependencies:
   - libpysal
   - cenpy
   - geopandas
-  - matplotlib >=3.3.4
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - hdbscan

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -8,7 +8,7 @@ dependencies:
   - libpysal
   - cenpy
   - geopandas
-  - matplotlib
+  - matplotlib >=3.3.4
   - scikit-learn
   - seaborn
   - hdbscan

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -34,7 +34,7 @@
             miniconda-version: 'latest'
             mamba-version: '*'
             channels: conda-forge
-            channel-priority: true
+            channel-priority: strict
             auto-update-conda: false
             auto-activate-base: false
             environment-file: ${{ matrix.environment-file }}

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - libpysal
   - cenpy
   - geopandas
-  - matplotlib
+  - matplotlib >=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - libpysal
   - cenpy
   - geopandas
-  - matplotlib >=3.3.4
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas
 geopandas
-matplotlib >=3.3.4
+matplotlib <=3.3.4
 scikit-learn
 seaborn
 libpysal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas
 geopandas
-matplotlib
+matplotlib >=3.3.4
 scikit-learn
 seaborn
 libpysal

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -3,7 +3,7 @@ nose-progressive
 nose-exclude
 coverage
 coveralls
-matplotlib >=3.3.4
+matplotlib <=3.3.4
 pytest
 pytest-mpl
 pytest-cov

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -3,7 +3,7 @@ nose-progressive
 nose-exclude
 coverage
 coveralls
-matplotlib
+matplotlib >=3.3.4
 pytest
 pytest-mpl
 pytest-cov


### PR DESCRIPTION
https://github.com/pysal/segregation/pull/166

I saw that this makes the builds take around 1.5x times longer, but this seems like a good stopgap to get the builds working again before redoing the unit tests to use mamba.

