### PR TITLE
refactor CI using provision-with-micromamba

### DIFF
--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -9,7 +9,7 @@ dependencies:
   - cenpy
   - geopandas
   - hdbscan
-  - matplotlib
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -9,7 +9,7 @@ dependencies:
   - cenpy
   - geopandas
   - hdbscan
-  - matplotlib
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - pyarrow >=0.14.1

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -8,7 +8,7 @@ dependencies:
   - libpysal
   - cenpy
   - geopandas
-  - matplotlib
+  - matplotlib <=3.3.4
   - scikit-learn
   - seaborn
   - hdbscan

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -32,15 +32,32 @@
            environment-file: ${{ matrix.environment-file }}
            micromamba-version: 'latest'
      
-       - name: install geosnap
+     
+       - name: install geosnap - bash
          shell: bash -l {0}
          run: pip install -e . --no-deps --force-reinstall
+         if: matrix.os != 'windows-latest'
        
-       - name: download data
+       - name: install geosnap - powershell
+         shell: powershell
+         run: pip install -e . --no-deps --force-reinstall
+         if: matrix.os == 'windows-latest'
+      
+      
+       - name: download data - bash
          shell: bash -l {0}
          run: python geosnap/tests/_dl_data.py
          env:
            COMBO_DATA: ${{ secrets.COMBO_DATA }}
+         if: matrix.os != 'windows-latest'
+      
+       - name: download data - powershell
+         shell: powershell
+         run: python geosnap/tests/_dl_data.py
+         env:
+           COMBO_DATA: ${{ secrets.COMBO_DATA }}
+         if: matrix.os == 'windows-latest'
+       
        
        - name: run tests - bash
          shell: bash -l {0}
@@ -60,6 +77,7 @@
            NCDB: ${{ secrets.COMBO_DATA }}
          if: matrix.os == 'windows-latest'
        
+       
        - name: codecov
          uses: codecov/codecov-action@v1
          with:
@@ -67,7 +85,13 @@
            file: ./coverage.xml
            name: geosnap-codecov
        
-       - name: notebook tests
-         if: ${{ env.COMBO_DATA }}
+       
+       - name: notebook tests - bash
+         if: ${{ env.COMBO_DATA }} && matrix.os != 'windows-latest'
          shell: bash -l {0}
+         run: jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=python3 examples/*.ipynb;
+         
+       - name: notebook tests - powershell
+         if: ${{ env.COMBO_DATA }} && matrix.os == 'windows-latest'
+         shell: powershell
          run: jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=python3 examples/*.ipynb;

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,11 +1,14 @@
- name: Unit Tests 
+ name: Continuous Integration
+ 
  on:
    push:
      branches:
-     - '*'
+       - '*'
    pull_request:
      branches:
-     - '*'
+       - '*'
+   schedule:
+       - cron: '59 23 * * *'
 
  jobs:
    unittests:
@@ -18,53 +21,53 @@
          os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
          environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml]
          experimental: [false]
-     defaults:
-        run:
-         shell: bash -l {0}
+     
      steps:
-       - uses: actions/checkout@v2
-       - uses: actions/cache@v2
-         env:
-           CACHE_NUMBER: 0
+       - name: checkout repo
+         uses: actions/checkout@v2
+       
+       - name: setup micromamba
+         uses: mamba-org/provision-with-micromamba@main
          with:
-           path: ~/conda_pkgs_dir
-           key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
-       - uses: conda-incubator/setup-miniconda@v2
-         with:
-            miniconda-version: 'latest'
-            mamba-version: '*'
-            channels: conda-forge
-            channel-priority: true
-            auto-update-conda: false
-            auto-activate-base: false
-            environment-file: ${{ matrix.environment-file }}
-            activate-environment: test
-            use-only-tar-bz2: true
-       - run: conda info --all
-       - run: conda list
-       - run: conda config --show-sources
-       - run: conda config --show
-       - run: pip install -e . --no-deps --force-reinstall
-       - name: Download Data
+           environment-file: ${{ matrix.environment-file }}
+           micromamba-version: 'latest'
+     
+       - name: install geosnap
+         shell: bash -l {0}
+         run: pip install -e . --no-deps --force-reinstall
+       
+       - name: download data
          shell: bash -l {0}
          run: python geosnap/tests/_dl_data.py
          env:
             COMBO_DATA: ${{ secrets.COMBO_DATA }}
-       - name: Pytest
+       
+       - name: run tests - bash
          shell: bash -l {0}
-         run: |
-           pytest -v geosnap --cov=geosnap --cov-report=xml
+         run: pytest -v geosnap --cov=geosnap --cov-report=xml
          env:
            LTDB_SAMPLE: ${{ secrets.COMBO_DATA }} # check whether we can pull secrets
            LTDB_FULL: ${{ secrets.COMBO_DATA }}
            NCDB: ${{ secrets.COMBO_DATA }}
-       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
+         if: matrix.os != 'windows-latest'
+       
+      - name: run tests - powershell
+         shell: powershell
+         run: pytest -v geosnap --cov=geosnap --cov-report=xml
+         env:
+           LTDB_SAMPLE: ${{ secrets.COMBO_DATA }} # check whether we can pull secrets
+           LTDB_FULL: ${{ secrets.COMBO_DATA }}
+           NCDB: ${{ secrets.COMBO_DATA }}
+         if: matrix.os == 'windows-latest'
+       
+       - name: codecov
          uses: codecov/codecov-action@v1
          with:
            token: ${{ secrets.CODECOV_TOKEN }}
            file: ./coverage.xml
            name: geosnap-codecov
-       - name: Notebook Tests
+       
+       - name: notebook tests
          if: ${{ env.COMBO_DATA }}
          shell: bash -l {0}
          run: jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=python3 examples/*.ipynb;

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -40,7 +40,7 @@
          shell: bash -l {0}
          run: python geosnap/tests/_dl_data.py
          env:
-            COMBO_DATA: ${{ secrets.COMBO_DATA }}
+           COMBO_DATA: ${{ secrets.COMBO_DATA }}
        
        - name: run tests - bash
          shell: bash -l {0}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -51,7 +51,7 @@
            NCDB: ${{ secrets.COMBO_DATA }}
          if: matrix.os != 'windows-latest'
        
-      - name: run tests - powershell
+       - name: run tests - powershell
          shell: powershell
          run: pytest -v geosnap --cov=geosnap --cov-report=xml
          env:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -84,14 +84,3 @@
            token: ${{ secrets.CODECOV_TOKEN }}
            file: ./coverage.xml
            name: geosnap-codecov
-       
-       
-       - name: notebook tests - bash
-         if: ${{ env.COMBO_DATA }} && matrix.os != 'windows-latest'
-         shell: bash -l {0}
-         run: jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=python3 examples/*.ipynb;
-         
-       - name: notebook tests - powershell
-         if: ${{ env.COMBO_DATA }} && matrix.os == 'windows-latest'
-         shell: powershell
-         run: jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=python3 examples/*.ipynb;


### PR DESCRIPTION
This PR updates the environment setup in `unittests.yml` to take advantage of [`provision-with-micromamba`](https://github.com/mamba-org/provision-with-micromamba). It is based on the current CI schema in [`spaghetti`](https://github.com/pysal/spaghetti/blob/main/.github/workflows/unittests.yml) where runtime is reduced by approx. half.