### PR TITLE
[WIP] start segregation dynamics module

### DIFF
--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -26,6 +26,7 @@ dependencies:
   - fsspec
   - s3fs
   - botocore >=1.20.21
+  - segregation >=2.0
   # testing
   - descartes
   - jupyter

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -26,6 +26,7 @@ dependencies:
   - fsspec
   - s3fs
   - botocore >=1.20.21
+  - segregation >=2.0
   # testing
   - descartes
   - jupyter

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -26,6 +26,8 @@ dependencies:
   - fsspec
   - s3fs
   - botocore >=1.20.21
+  - segregation >=2.0
+
   # testing
   - descartes
   - jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -30,4 +30,6 @@ dependencies:
   - fsspec
   - s3fs
   - botocore >=1.20.21
+  - segregation >=2.0
+
   

--- a/geosnap/_community.py
+++ b/geosnap/_community.py
@@ -1697,14 +1697,14 @@ class Community:
             states = None
 
         df_dict = {
-            1990: datasets.tracts_1990(states=states),
-            2000: datasets.tracts_2000(states=states),
-            2010: datasets.tracts_2010(states=states),
+            1990: datasets.tracts_1990,
+            2000: datasets.tracts_2000,
+            2010: datasets.tracts_2010,
         }
 
         tracts = []
         for year in years:
-            tracts.append(df_dict[year])
+            tracts.append(df_dict[year](states=states))
         tracts = pd.concat(tracts, sort=False)
 
         if isinstance(boundary, gpd.GeoDataFrame):

--- a/geosnap/analyze/__init__.py
+++ b/geosnap/analyze/__init__.py
@@ -1,3 +1,4 @@
 from .analytics import cluster, regionalize, ModelResults, predict_labels
 from .dynamics import sequence, transition
 from .incs import linc
+from . import segdyn

--- a/geosnap/analyze/segdyn.py
+++ b/geosnap/analyze/segdyn.py
@@ -1,0 +1,83 @@
+import pandas as pd
+
+from segregation import batch, dynamics
+
+try:  # pandarallel gives parallel_apply in pandas
+    from pandarallel import pandarallel
+
+    pandarallel.initialize(verbose=1)
+    USE_PARALLEL = True
+except ImportError:
+    USE_PARALLEL = False
+
+
+def singlegroup_tempdyn(
+    gdf, group_pop=None, comp_pop=None, time_index="year", **index_kwargs
+):
+    if not index_kwargs:
+        index_kwargs = {}
+    if USE_PARALLEL:
+        gdf = gdf.groupby(time_index).parallel_apply(
+            lambda x: batch.batch_compute_singlegroup(
+                x, group_pop_var=group_pop, total_pop_var=comp_pop, **index_kwargs
+            )
+        )
+    else:
+        gdf = gdf.groupby(time_index).apply(
+            lambda x: batch.batch_compute_singlegroup(
+                x, group_pop_var=group_pop, total_pop_var=comp_pop, **index_kwargs
+            )
+        )
+    gdf = gdf.unstack().T.reset_index(level=0, drop=True)
+
+    return gdf
+
+
+def multigroup_tempdyn(gdf, groups=None, time_index="year", index_kwargs=None):
+    if not index_kwargs:
+        index_kwargs = {}
+    if not index_kwargs:
+        index_kwargs = {}
+    if USE_PARALLEL:
+        gdf = gdf.groupby(time_index).parallel_apply(
+            lambda x: batch.batch_compute_multigroup(x, groups=groups, **index_kwargs)
+        )
+    else:
+        gdf = gdf.groupby(time_index).apply(
+            lambda x: batch.batch_compute_multigroup(x, groups=groups, **index_kwargs)
+        )
+    gdf = gdf.unstack().T.reset_index(level=0, drop=True)
+
+    return gdf
+
+
+def spacetime_dyn(
+    gdf,
+    seg_stat=None,
+    group_pop=None,
+    total_pop=None,
+    time_index="year",
+    distances=None,
+):
+    if USE_PARALLEL:
+        gdf = gdf.groupby(time_index).parallel_apply(
+            lambda x: dynamics.compute_multiscalar_profile(
+                x,
+                segregation_index=seg_stat,
+                group_pop_var=group_pop,
+                total_pop_var=total_pop,
+                distances=distances,
+            )
+        )
+    else:
+        gdf = gdf.groupby(time_index).apply(
+            lambda x: dynamics.compute_multiscalar_profile(
+                x,
+                segregation_index=seg_stat,
+                group_pop_var=group_pop,
+                total_pop_var=total_pop,
+                distances=distances,
+            )
+        )
+
+    return pd.DataFrame(gdf).T  # convert back to regular DataFrame without geometry

--- a/geosnap/analyze/segdyn.py
+++ b/geosnap/analyze/segdyn.py
@@ -1,51 +1,62 @@
 import pandas as pd
-
+from joblib import Parallel, delayed
 from segregation import batch, dynamics
-
-try:  # pandarallel gives parallel_apply in pandas
-    from pandarallel import pandarallel
-
-    pandarallel.initialize(verbose=1)
-    USE_PARALLEL = True
-except ImportError:
-    USE_PARALLEL = False
 
 
 def singlegroup_tempdyn(
-    gdf, group_pop=None, comp_pop=None, time_index="year", **index_kwargs
+    gdf,
+    group_pop_var=None,
+    total_pop_var=None,
+    time_index="year",
+    n_jobs=-1,
+    backend="loky",
+    **index_kwargs
 ):
-    if not index_kwargs:
-        index_kwargs = {}
-    if USE_PARALLEL:
-        gdf = gdf.groupby(time_index).parallel_apply(
-            lambda x: batch.batch_compute_singlegroup(
-                x, group_pop_var=group_pop, total_pop_var=comp_pop, **index_kwargs
-            )
-        )
-    else:
-        gdf = gdf.groupby(time_index).apply(
-            lambda x: batch.batch_compute_singlegroup(
-                x, group_pop_var=group_pop, total_pop_var=comp_pop, **index_kwargs
-            )
-        )
-    gdf = gdf.unstack().T.reset_index(level=0, drop=True)
+    # essentially implement a parallelized grouby-apply
+    input_args = locals()
+    input_args.pop("gdf")
+    input_args[
+        "backend"
+    ] = "multiprocessing"  # threading backend fails for modified gini and dissim
+    # Create a tuple of (df, arguments) for each unique time period to pass to the parallel function
+    dataframes = tuple([[group, input_args] for _, group in gdf.groupby(time_index)])
+    estimates = Parallel(n_jobs=n_jobs, backend=backend)(
+        delayed(_prep_single)(i) for i in dataframes
+    )
+    gdf = pd.concat(estimates)
+    gdf = gdf.pivot(columns=time_index)
+    gdf = gdf.T.reset_index(level=0, drop=True).T  # don't want a multiindex
+    return gdf
 
+
+def _prep_single(group):
+    args = group[1]
+    time = group[0][args["time_index"]].iloc[0]
+    gdf = batch.batch_compute_singlegroup(group[0], **args)
+    gdf[args["time_index"]] = time
+    return gdf
+
+
+def _prep_prof(group):
+    args = group[1]
+    time = group[0][args["time_index"]].iloc[0]
+    tindex_name = args["time_index"]
+    args.pop("time_index")
+    args.pop("n_jobs")
+    args.pop("backend")
+    gdf = dynamics.compute_multiscalar_profile(group[0], **args)
+    gdf = gdf.to_frame()
+    gdf.columns = [time]
     return gdf
 
 
 def multigroup_tempdyn(gdf, groups=None, time_index="year", index_kwargs=None):
+    # could parallelize this, but the indices are fast enough it's not clearly worth it
     if not index_kwargs:
         index_kwargs = {}
-    if not index_kwargs:
-        index_kwargs = {}
-    if USE_PARALLEL:
-        gdf = gdf.groupby(time_index).parallel_apply(
-            lambda x: batch.batch_compute_multigroup(x, groups=groups, **index_kwargs)
-        )
-    else:
-        gdf = gdf.groupby(time_index).apply(
-            lambda x: batch.batch_compute_multigroup(x, groups=groups, **index_kwargs)
-        )
+    gdf = gdf.groupby(time_index).apply(
+        lambda x: batch.batch_compute_multigroup(x, groups=groups, **index_kwargs)
+    )
     gdf = gdf.unstack().T.reset_index(level=0, drop=True)
 
     return gdf
@@ -53,31 +64,26 @@ def multigroup_tempdyn(gdf, groups=None, time_index="year", index_kwargs=None):
 
 def spacetime_dyn(
     gdf,
-    seg_stat=None,
-    group_pop=None,
-    total_pop=None,
+    segregation_index=None,
+    group_pop_var=None,
+    total_pop_var=None,
+    groups=None,
     time_index="year",
     distances=None,
+    n_jobs=-1,
+    backend="loky",
 ):
-    if USE_PARALLEL:
-        gdf = gdf.groupby(time_index).parallel_apply(
-            lambda x: dynamics.compute_multiscalar_profile(
-                x,
-                segregation_index=seg_stat,
-                group_pop_var=group_pop,
-                total_pop_var=total_pop,
-                distances=distances,
-            )
-        )
-    else:
-        gdf = gdf.groupby(time_index).apply(
-            lambda x: dynamics.compute_multiscalar_profile(
-                x,
-                segregation_index=seg_stat,
-                group_pop_var=group_pop,
-                total_pop_var=total_pop,
-                distances=distances,
-            )
-        )
+    # essentially implement a parallelized grouby-apply
+    input_args = locals()
+    input_args.pop("gdf")
+    input_args[
+        "backend"
+    ] = "multiprocessing"  # threading backend fails for modified gini and dissim
+    # Create a tuple of (df, arguments) for each unique time period to pass to the parallel function
+    dataframes = tuple([[group, input_args] for _, group in gdf.groupby(time_index)])
+    estimates = Parallel(n_jobs=n_jobs, backend=backend)(
+        delayed(_prep_prof)(i) for i in dataframes
+    )
+    gdf = pd.concat(estimates, axis=1)
 
-    return pd.DataFrame(gdf).T  # convert back to regular DataFrame without geometry
+    return gdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ spopt>=0.1.1
 fsspec
 s3fs
 botocore >=1.20.21
+segregation>=2.0


### PR DESCRIPTION
this PR addresses #77, providing parallelized wrappers around `segregation`'s batch_compute functions. Once merged, geosnap users can quickly examine the ways that segregation has changed in a given region over time (and whether those changes are consistent across spatial scales and dimensions of segregation)

remaining to to:

- [ ] finalize function nomenclature
- [ ] add docstrings
- [ ] update docs
- [ ] push example notebook